### PR TITLE
Update Decoder.php

### DIFF
--- a/src/Decoder.php
+++ b/src/Decoder.php
@@ -214,7 +214,7 @@ class Decoder implements DecoderInterface
                 );
 
                 if ($this->currentFrame->isTransparent()) {
-                    $color = new Color();
+                    $color = new Color(-1, -1, -1);
                     $color->index = $this->buffer[3];
                     $this->currentFrame->setTransparentColor($color);
                 }


### PR DESCRIPTION
I'm not 100% sure this is correct, but the `Color()` class constructor requires RGB values (their defaults are all -1). When a new `Color()` is instantiated on line 217, there's no args passed, this throws a ErrorException. Setting the values here to -1, -1, -1 correctly instantiates a new `Color()`.
