### PR TITLE
pass the frame in the renderer#start() callback.

### DIFF
--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -27,7 +27,7 @@ class Renderer
     public function start(callable $onFrameRendered)
     {
         $this->decoder->decode(function (Frame $frame, $index) use ($onFrameRendered) {
-            $onFrameRendered($this->render($frame, $index), $index);
+            $onFrameRendered($frame, $this->render($frame, $index), $index);
         });
     }
 


### PR DESCRIPTION
Otherwise we can't even get the frame's information from the callback function.
